### PR TITLE
Fix typehints

### DIFF
--- a/src/biocframe/BiocFrame.py
+++ b/src/biocframe/BiocFrame.py
@@ -158,6 +158,10 @@ class BiocFrame:
         Raises:
             ValueError: if provided names not the same as number of columns.
         """
+
+        if names is None:
+            raise ValueError("Column names cannot be None!")
+
         if len(names) != self._numberOfColumns:
             raise ValueError(
                 "Incorrect length of `names`, need to be "

--- a/src/biocframe/BiocFrame.py
+++ b/src/biocframe/BiocFrame.py
@@ -452,6 +452,7 @@ class BiocFrame:
             raise ValueError(f"Column: {name} does not exist.")
 
         del self._data[name]
+        self._columnNames.remove(name)
         self._numberOfColumns -= 1
 
     def __len__(self) -> int:

--- a/src/biocframe/BiocFrame.py
+++ b/src/biocframe/BiocFrame.py
@@ -117,23 +117,25 @@ class BiocFrame:
         return self._data
 
     @rowNames.setter
-    def rowNames(self, names: Sequence[str]):
+    def rowNames(self, names: Optional[Sequence[str]]):
         """Set new index.
 
         Args:
-            names (Sequence[str]): new row names to set as index.
+            names (Sequence[str], optional): new row names to set as index.
 
         Raises:
             ValueError: if length of new index not the same as number of rows.
         """
-        if len(names) != self._numberOfRows:
-            raise ValueError(
-                "Incorrect length of `names`, need to be "
-                f"{self._numberOfRows} but provided {len(names)}"
-            )
 
-        if not (validate_unique_list(names)):
-            raise ValueError("names must be unique!")
+        if names is not None:
+            if len(names) != self._numberOfRows:
+                raise ValueError(
+                    "Incorrect length of `names`, need to be "
+                    f"{self._numberOfRows} but provided {len(names)}"
+                )
+
+            if not (validate_unique_list(names)):
+                raise ValueError("names must be unique!")
 
         self._rowNames = names
 

--- a/src/biocframe/BiocFrame.py
+++ b/src/biocframe/BiocFrame.py
@@ -108,11 +108,12 @@ class BiocFrame:
         return self._rowNames
 
     @property
-    def data(self) -> MutableMapping[str, Any]:
+    def data(self) -> MutableMapping[str, Union[List[Any], MutableMapping]]:
         """Access data (as dictionary).
 
         Returns:
-            MutableMapping[str, Any]: dictionary of columns and their values.
+            MutableMapping[str, Union[List[Any], MutableMapping]]: 
+                dictionary of columns and their values.
         """
         return self._data
 


### PR DESCRIPTION
https://github.com/BiocPy/BiocFrame/issues/6

- `data` does not have a setter so it can never be set directly
- `rowNames` aka row index can be set to None, made changes that would allow this. 
- similarly `colNames` cannot be set to None, if thats the case, data must be an empty object. might as well just start with an new BiocFrame object. 