### PR TITLE
Avoid pass-by-reference effects when setting or removing columns.

### DIFF
--- a/src/biocframe/BiocFrame.py
+++ b/src/biocframe/BiocFrame.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 from warnings import warn
+from copy import copy
 
 import biocutils as ut
 
@@ -1022,6 +1023,9 @@ class BiocFrame:
             or as a reference to the (in-place-modified) original.
         """
         output = self._define_output(in_place)
+        if not in_place:
+            output._data = copy(output._data)
+
         if isinstance(args, tuple):
             rows, cols = args
 
@@ -1053,6 +1057,8 @@ class BiocFrame:
                 )
 
             if args not in output.column_names:
+                if not in_place:
+                    output._column_names = copy(output._column_names)
                 output._column_names.append(args)
 
                 if output._mcols is not None:
@@ -1082,6 +1088,9 @@ class BiocFrame:
             raise ValueError(f"Column: '{name}' does not exist.")
 
         output = self._define_output(in_place)
+        if not in_place:
+            output._data = copy(output._data)
+            output._column_names = copy(output._column_names)
 
         del output._data[name]
         _col_idx = output._column_names.index(name)

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -560,9 +560,9 @@ def test_remove_column():
     assert obj.has_column("column2")
     assert not out.has_column("column2")
 
-    out = obj.remove_column(0)
+    out = obj.remove_column("column1")
     assert obj.has_column("column1")
     assert not out.has_column("column1")
 
-    obj.remove_column(1, in_place=True)
+    obj.remove_column("column2", in_place=True)
     assert not obj.has_column("column2")

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -108,19 +108,18 @@ def test_bframe_setters():
     bframe.metadata = {"a": "b"}
     assert bframe.metadata is not None
 
-    bframe["new_col"] = [1, 2, 3]
+    bframe2 = bframe.set_column("new_col", [1, 2, 3])
+    assert bframe2.column("new_col") == [1,2,3]
+    assert not bframe.has_column("new_col")
+    assert bframe2.dims == (3, 4)
 
-    assert bframe is not None
+    bframe2 = bframe.set_column("col3", [1, 2, 3])
+    assert bframe2.column("col3") == [1,2,3]
+    assert bframe.column("col3") == ["b", "n", "m"]
+    assert bframe2.dims == (3, 3)
 
-    assert len(bframe.dims) == 2
-    assert bframe.dims == (3, 4)
-
-    bframe["col2"] = [1, 2, 3]
-
-    assert bframe is not None
-
-    assert len(bframe.dims) == 2
-    assert bframe.dims == (3, 4)
+    bframe.set_column("col3", [1, 2, 3], in_place=True)
+    assert bframe.column("col3") == [1,2,3]
 
 
 def test_bframe_setters_with_rows():
@@ -547,3 +546,23 @@ def test_set_names():
     with pytest.raises(ValueError) as ex:
         obj.set_column_names(["A", "A"])
     assert str(ex.value).find("duplicate column name") >= 0
+
+
+def test_remove_column():
+    obj = BiocFrame(
+        {
+            "column1": [1, 2, 3],
+            "column2": [4, 5, 6],
+        }
+    )
+
+    out = obj.remove_column("column2")
+    assert obj.has_column("column2")
+    assert not out.has_column("column2")
+
+    out = obj.remove_column(0)
+    assert obj.has_column("column1")
+    assert not out.has_column("column1")
+
+    obj.remove_column(1, in_place=True)
+    assert not obj.has_column("column2")


### PR DESCRIPTION
Closes #64. Also deals with the related point for `remove_column` in #67.