### PR TITLE
Renamed mcols to column_data.

### DIFF
--- a/src/biocframe/BiocFrame.py
+++ b/src/biocframe/BiocFrame.py
@@ -1270,7 +1270,9 @@ class BiocFrame:
         _num_rows_copy = deepcopy(self._number_of_rows)
         _rownames_copy = deepcopy(self.row_names)
         _metadata_copy = deepcopy(self.metadata)
-        _column_data_copy = deepcopy(self._column_data) if self._column_data is not None else None
+        _column_data_copy = (
+            deepcopy(self._column_data) if self._column_data is not None else None
+        )
 
         # copy dictionary first
         _data_copy = OrderedDict()

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -101,7 +101,7 @@ def test_combine_with_extras():
             "column1": [1, 2, 3],
             "column2": [4, 5, 6],
         },
-        mcols=BiocFrame({"foo": [-1, -2], "bar": ["A", "B"]}),
+        column_data=BiocFrame({"foo": [-1, -2], "bar": ["A", "B"]}),
         metadata={"YAY": 2},
     )
 
@@ -114,7 +114,7 @@ def test_combine_with_extras():
 
     merged = combine(obj1, obj2)
     assert merged.metadata == obj1.metadata
-    assert merged.mcols.shape == obj1.mcols.shape
+    assert merged.column_data.shape == obj1.column_data.shape
 
 
 def test_relaxed_combine_rows():
@@ -186,7 +186,7 @@ def test_combine_columns_basic():
     assert str(ex.value).find("same number of rows") >= 0
 
 
-def test_combine_columns_with_mcols():
+def test_combine_columns_with_column_data():
     obj1 = BiocFrame(
         {
             "odd": [1, 3, 5, 7, 9],
@@ -202,14 +202,14 @@ def test_combine_columns_with_mcols():
     )
 
     merged = combine_columns(obj1, obj2)
-    assert merged.get_mcols() is None
+    assert merged.get_column_data() is None
 
-    obj1.set_mcols(BiocFrame({"A": [1, 2]}), in_place=True)
-    obj2.set_mcols(BiocFrame({"A": [3, 4]}), in_place=True)
+    obj1.set_column_data(BiocFrame({"A": [1, 2]}), in_place=True)
+    obj2.set_column_data(BiocFrame({"A": [3, 4]}), in_place=True)
     merged = combine_columns(obj1, obj2)
-    assert merged.get_mcols().column("A") == [1, 2, 3, 4]
+    assert merged.get_column_data().column("A") == [1, 2, 3, 4]
 
-    obj1.set_mcols(None, in_place=True)
+    obj1.set_column_data(None, in_place=True)
     with pytest.raises(ValueError) as ex:
         combine_columns(obj1, obj2)
-    assert str(ex.value).find("Failed to combine 'mcols'") >= 0
+    assert str(ex.value).find("Failed to combine 'column_data'") >= 0

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -124,16 +124,16 @@ def test_extra_bits():
         {
             "column1": [1, 2, 3],
         },
-        mcols=BiocFrame({"foo": [1], "bar": ["A"]}),
+        column_data=BiocFrame({"foo": [1], "bar": ["A"]}),
         metadata={"YAY": 2},
     )
 
-    assert isinstance(bframe.mcols, BiocFrame)
+    assert isinstance(bframe.column_data, BiocFrame)
     assert bframe.metadata["YAY"] == 2
 
     # Setters work correctly.
-    bframe.mcols = BiocFrame({"STUFF": [2.5]})
-    assert bframe.mcols.column_names == ["STUFF"]
+    bframe.column_data = BiocFrame({"STUFF": [2.5]})
+    assert bframe.column_data.column_names == ["STUFF"]
 
     bframe.metadata = {"FOO": "A"}
     assert bframe.metadata["FOO"] == "A"
@@ -145,23 +145,23 @@ def test_with_add_deletions():
             "column1": [1, 2, 3],
             "column2": [4, 5, 6],
         },
-        mcols=BiocFrame({"foo": [-1, -2], "bar": ["A", "B"]}),
+        column_data=BiocFrame({"foo": [-1, -2], "bar": ["A", "B"]}),
         metadata={"YAY": 2},
     )
 
-    assert isinstance(obj1.mcols, BiocFrame)
+    assert isinstance(obj1.column_data, BiocFrame)
 
     obj1["new_column"] = [10, 11, "12"]
     assert obj1.shape == (3, 3)
-    assert len(obj1.mcols) == 3
+    assert len(obj1.column_data) == 3
 
     # welp assume i made a mistake earlier
     obj1["new_column"] = [10, 11, 12]
     assert obj1.shape == (3, 3)
-    assert len(obj1.mcols) == 3
+    assert len(obj1.column_data) == 3
 
     # lets delete
     del obj1["new_column"]
     assert obj1.shape == (3, 2)
-    print(obj1.mcols)
-    assert len(obj1.mcols) == 2
+    print(obj1.column_data)
+    assert len(obj1.column_data) == 2

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -121,7 +121,7 @@ def test_merge_BiocFrame_duplicate_columns():
     assert combined.column("B (2)") == [3, 4, 5, 6]
 
 
-def test_merge_BiocFrame_mcols():
+def test_merge_BiocFrame_column_data():
     # A simple case.
     obj1 = BiocFrame({"B": [3, 4, 5, 6]}, row_names=[1, 2, 3, 4])
     obj2 = BiocFrame(
@@ -130,17 +130,17 @@ def test_merge_BiocFrame_mcols():
     )
 
     combined = merge([obj1, obj2], by=None, join="left")
-    assert combined.get_mcols() is None
+    assert combined.get_column_data() is None
 
-    obj1.set_mcols(BiocFrame({"foo": [True]}), in_place=True)
+    obj1.set_column_data(BiocFrame({"foo": [True]}), in_place=True)
     combined = merge([obj1, obj2], by=None, join="left")
-    comcol = combined.get_mcols()
+    comcol = combined.get_column_data()
     assert combined.get_column_names() == ["B", "C"]
     assert comcol.column("foo") == [True, None]
 
-    obj2.set_mcols(BiocFrame({"foo": [False]}), in_place=True)
+    obj2.set_column_data(BiocFrame({"foo": [False]}), in_place=True)
     combined = merge([obj1, obj2], by=None, join="left")
-    comcol = combined.get_mcols()
+    comcol = combined.get_column_data()
     assert comcol.column("foo") == [True, False]
 
     # Now a more complicated case.
@@ -158,15 +158,15 @@ def test_merge_BiocFrame_mcols():
     )
 
     combined = merge([obj1, obj2], by="A", join="left")
-    assert combined.get_mcols() is None
+    assert combined.get_column_data() is None
 
-    obj1.set_mcols(BiocFrame({"foo": [True, False]}), in_place=True)
+    obj1.set_column_data(BiocFrame({"foo": [True, False]}), in_place=True)
     combined = merge([obj1, obj2], by="A", join="left")
-    comcol = combined.get_mcols()
+    comcol = combined.get_column_data()
     assert combined.get_column_names() == ["B", "A", "C"]
     assert comcol.column("foo") == [True, False, None]
 
-    obj2.set_mcols(BiocFrame({"foo": ["WHEE", False]}), in_place=True)
+    obj2.set_column_data(BiocFrame({"foo": ["WHEE", False]}), in_place=True)
     combined = merge([obj1, obj2], by="A", join="left")
-    comcol = combined.get_mcols()
+    comcol = combined.get_column_data()
     assert comcol.column("foo") == [True, False, False]

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -147,8 +147,8 @@ def test_bframe_set_columns():
     assert bframe2.column("column1") == ["A", "B", "C"]
     assert bframe2.column("column2") == ["a", "b", "c"]
 
-    # Making sure that the mcols is properly handled.
-    bframe2a = bframe.set_mcols(
+    # Making sure that the column_data is properly handled.
+    bframe2a = bframe.set_column_data(
         BiocFrame(
             {
                 "prop1": [1, 2],
@@ -160,17 +160,17 @@ def test_bframe_set_columns():
     bframe2b = bframe2a.set_columns(
         {"column1": ["A", "B", "C"], "column3": ["a", "b", "c"], "column4": [9, 8, 7]}
     )
-    final_mcols = bframe2b.get_mcols()
-    assert final_mcols.column("prop1") == [1, 2, None, None]
-    assert final_mcols.column("prop2").dtype == np.int32
+    final_column_data = bframe2b.get_column_data()
+    assert final_column_data.column("prop1") == [1, 2, None, None]
+    assert final_column_data.column("prop2").dtype == np.int32
     assert (
-        list(final_mcols.column("prop2"))
-        == list(bframe2a.get_mcols().column("prop2")) + [np.ma.masked] * 2
+        list(final_column_data.column("prop2"))
+        == list(bframe2a.get_column_data().column("prop2")) + [np.ma.masked] * 2
     )
-    assert final_mcols.column("prop3").dtype == np.int8
+    assert final_column_data.column("prop3").dtype == np.int8
     assert (
-        list(final_mcols.column("prop3"))
-        == list(bframe2a.get_mcols().column("prop3")) + [np.ma.masked] * 2
+        list(final_column_data.column("prop3"))
+        == list(bframe2a.get_column_data().column("prop3")) + [np.ma.masked] * 2
     )
 
 
@@ -322,17 +322,17 @@ def test_bframe_slice_with_extras():
             "column1": [1, 2, 3],
             "column2": [4, 5, 6],
         },
-        mcols=BiocFrame({"foo": [-1, -2], "bar": ["A", "B"]}),
+        column_data=BiocFrame({"foo": [-1, -2], "bar": ["A", "B"]}),
         metadata={"YAY": 2},
     )
 
     subframe = bframe[0:2, :]
-    assert subframe.mcols.shape[0] == bframe.mcols.shape[1]
+    assert subframe.column_data.shape[0] == bframe.column_data.shape[1]
     assert subframe.metadata == bframe.metadata
 
     subframe = bframe[:, [1]]
-    assert subframe.mcols.shape[0] == 1
-    assert subframe.mcols.column("foo") == [-2]
+    assert subframe.column_data.shape[0] == 1
+    assert subframe.column_data.column("foo") == [-2]
     assert subframe.metadata == bframe.metadata
 
 
@@ -400,10 +400,10 @@ def test_bframe_remove_column():
     assert copy.has_column("column2")
     assert copy.shape == (3, 1)
 
-    # Handles the mcols correctly.
-    bframe2a = bframe.set_mcols(BiocFrame({"prop1": [1, 2]}))
+    # Handles the column_data correctly.
+    bframe2a = bframe.set_column_data(BiocFrame({"prop1": [1, 2]}))
     bframe2b = bframe2a.remove_column("column1")
-    assert bframe2b.get_mcols().column("prop1") == [2]
+    assert bframe2b.get_column_data().column("prop1") == [2]
 
 
 def test_bframe_ufuncs():


### PR DESCRIPTION
Closes #68.

Currently, the length of a BiocFrame is the number of rows, while the mcols contain metadata on the columns. This means that we violate the basic contract of mcols, i.e., that it is parallel to the object length. (Indeed, we were already verging on violating it anyway because the BiocFrame mcols needs to be None-able to avoid an infinite recursion during construction.)

So, the simple solution is to just rename it to column_data, which frees us from the mcols contract and is arguably more descriptive for a 2-dimensional object. This change aligns us with other 2D classes like SummarizedExperiment.