### PR TITLE
Fix condition check for arguments when slicing

### DIFF
--- a/src/biocframe/BiocFrame.py
+++ b/src/biocframe/BiocFrame.py
@@ -699,7 +699,7 @@ class BiocFrame:
             A ``BiocFrame`` with the specified rows and columns.
         """
         new_column_names = self._column_names
-        if columns != slice(None):
+        if not (isinstance(columns, slice) and columns == slice(None)):
             new_column_indices, _ = ut.normalize_subscript(
                 columns, len(new_column_names), new_column_names
             )
@@ -711,7 +711,7 @@ class BiocFrame:
 
         new_row_names = self._row_names
         new_number_of_rows = self.shape[0]
-        if rows != slice(None):
+        if not (isinstance(rows, slice) and rows == slice(None)):
             new_row_names = self.row_names
             new_row_indices, _ = ut.normalize_subscript(
                 rows, self.shape[0], new_row_names


### PR DESCRIPTION
Fixes issues with slice checks when rows is a numpy vector

```pyt
>       if rows != slice(None):
E       ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

../BiocFrame/src/biocframe/BiocFrame.py:714: ValueError
```

and the arguments are

```pyt
self = BiocFrame(data={'detected': [4, 5, 6], 'subset_totals': BiocFrame(data={'foo': [7, 8, 9]}, number_of_rows=3, column_names=['foo'])}, number_of_rows=3, row_names=['A', 'B', 'C'], column_names=['detected', 'subset_totals'])
rows = array([0, 1, 2], dtype=int8), columns = slice(None, None, None)
```